### PR TITLE
Async Publisher support for asserting first value

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ func testSingleValueCompletingPublisher() {
         .expectSuccess()
         .waitForExpectations(timeout: 1)
 }
+
+func testSingleValueCompletingPublisher() async throws {
+    let value = somePublisher.awaitFirstValue()
+    XCTAssertEqual(value, someEquatableValue)
+}
 ```
 
 For a `Publisher` that is expected to emit multiple values, but is expected to not complete

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ func testSingleValueCompletingPublisher() {
 }
 
 func testSingleValueCompletingPublisher() async throws {
-    let value = somePublisher.awaitFirstValue()
+    let value = try await somePublisher.awaitFirstValue()
     XCTAssertEqual(value, someEquatableValue)
 }
 ```

--- a/Sources/TestableCombinePublishers/Publisher+Async.swift
+++ b/Sources/TestableCombinePublishers/Publisher+Async.swift
@@ -1,0 +1,63 @@
+//
+//  Publisher+Async.swift
+//  TestableCombinePublishers
+//
+//  Copyright (c) 2022 Albert Bori
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Combine
+import Foundation
+import XCTest
+
+public extension Publisher {
+    
+    /// Asynchronous function for getting the first published value.
+    /// - Returns: The first published value
+    /// - Throws: An error from a `Publisher` or an ``AsyncPublisherError`` if the publisher finishes without emitting a value.
+    /// - Note: The `Publisher` will be canceled after the first value is emitted.
+    func awaitFirstValue() async throws -> Output {
+        try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            var finishedWithoutValue = true
+            cancellable = first()
+                .sink { result in
+                    switch result {
+                    case .finished:
+                        if finishedWithoutValue {
+                            continuation.resume(throwing: AsyncPublisherError.finishedWithoutValue)
+                        }
+                    case let .failure(error):
+                        continuation.resume(throwing: error)
+                    }
+                    cancellable?.cancel()
+                } receiveValue: { value in
+                    finishedWithoutValue = false
+                    continuation.resume(with: .success(value))
+                }
+        }
+    }
+}
+
+/// Errors that can be thrown when using `async` functions on a `Publisher`
+public enum AsyncPublisherError: Error {
+    /// Throws when a `Publisher` is finished but no value was emitted from the `Publisher`
+    case finishedWithoutValue
+}

--- a/Sources/TestableCombinePublishers/Publisher+Async.swift
+++ b/Sources/TestableCombinePublishers/Publisher+Async.swift
@@ -62,6 +62,4 @@ public extension Publisher {
 public enum AsyncPublisherError: Error {
     /// Throws when a `Publisher` is finished but no value was emitted from the `Publisher`
     case finishedWithoutValue
-    /// Throws when a `Publisher` does not return it's value before the timeout
-    case timeout
 }

--- a/Tests/TestableCombinePublishersTests/AsyncPublisherTests.swift
+++ b/Tests/TestableCombinePublishersTests/AsyncPublisherTests.swift
@@ -1,0 +1,71 @@
+//
+//  AsyncPublisherTests.swift
+//  TestableCombinePublishers
+//
+//  Copyright (c) 2022 Albert Bori
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Combine
+import XCTest
+import TestableCombinePublishers
+
+class AsyncPublisherTest: XCTestCase {
+    
+    func testFail() async throws {
+        enum TestError: Error, Equatable {
+            case expectedTestError
+        }
+        
+        do {
+            _ = try await Fail<String, Error>(error: TestError.expectedTestError).awaitFirstValue()
+            XCTFail("This should not pass")
+        } catch let error as TestError {
+            XCTAssertEqual(error, .expectedTestError)
+        }
+    }
+    
+    func testFinishedWithoutValue() async throws {
+        do {
+            let subject = PassthroughSubject<String, Error>()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                subject.send(completion: .finished)
+            }
+            
+            _ = try await subject.awaitFirstValue()
+            XCTFail("This should not pass")
+        } catch let error as AsyncPublisherError {
+            XCTAssertEqual(error, .finishedWithoutValue)
+        }
+    }
+    
+    func testPass() async throws {
+        let value = try await CurrentValueSubject<String, Error>("foo").awaitFirstValue()
+        XCTAssertEqual(value, "foo")
+    }
+    
+    func testPassDelayed() async throws {
+        let value = try await CurrentValueSubject<String, Error>("foo")
+            .delay(for: 0.1, scheduler: DispatchQueue.main)
+            .awaitFirstValue()
+        XCTAssertEqual(value, "foo")
+    }
+    
+}

--- a/Tests/TestableCombinePublishersTests/AsyncPublisherTests.swift
+++ b/Tests/TestableCombinePublishersTests/AsyncPublisherTests.swift
@@ -56,6 +56,16 @@ class AsyncPublisherTest: XCTestCase {
         }
     }
     
+    func testPublisherNeverEmitsValue() async throws {
+        do {
+            let subject = PassthroughSubject<String, Error>()
+            _ = try await subject.awaitFirstValue()
+            XCTFail("This should not pass")
+        } catch let error as AsyncPublisherError {
+            XCTAssertEqual(error, .finishedWithoutValue)
+        }
+    }
+    
     func testPass() async throws {
         let value = try await CurrentValueSubject<String, Error>("foo").awaitFirstValue()
         XCTAssertEqual(value, "foo")

--- a/Tests/TestableCombinePublishersTests/ExampleTest.swift
+++ b/Tests/TestableCombinePublishersTests/ExampleTest.swift
@@ -1,5 +1,5 @@
 //
-//  TestableCombinePublishersTests.swift
+//  ExampleTest.swift
 //  TestableCombinePublishers
 //
 //  Copyright (c) 2022 Albert Bori

--- a/Tests/TestableCombinePublishersTests/ExampleTest.swift
+++ b/Tests/TestableCombinePublishersTests/ExampleTest.swift
@@ -44,4 +44,8 @@ class ExampleTest: XCTestCase {
             .waitForExpectations(timeout: 1)
     }
 
+    func testPassAsync() async throws {
+        let value = try await CurrentValueSubject<String, Error>("foo").awaitFirstValue()
+        XCTAssertEqual(value, "foo")
+    }
 }


### PR DESCRIPTION
Wanted to leverage `async await` for the times where you only need a single value from a publisher. This API will improve testing ergonomics and will improve test stability because tests will always wait for an appropriate time instead of guessing how long a test needs to run with `waitForExpectations`.