### PR TITLE
Fixed AutomaticallyEquatable Object Recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,9 @@ This is an imperfect and assuming implementation of `Equatable`. It should not b
 
 The implementation:
 
-- Cannot anticipate the consequences of observing a calculated property. (ie, code that changes the state of data when a property is observed).
+- Is subject to the consequences of observing a calculated property. (ie, code that changes the state of data when a property is observed).
 - Cannot respect custom `Equatable` implementations of the values being compared or any of the subsequent members. It will use its own comparison logic instead.
 - Skips over members that cannot be reasonably compared, such as closures. These are assumed to be equal.
-- Does not support recursive evaluation of reflexive types (it will crash if a property on a type references itself)
 
 ## Usage
 

--- a/Sources/TestableCombinePublishers/AutomaticallyEquatable.swift
+++ b/Sources/TestableCombinePublishers/AutomaticallyEquatable.swift
@@ -19,10 +19,9 @@ import Foundation
 ///
 /// The implementation:
 ///
-/// - Cannot anticipate the consequences of observing a calculated property. (ie, code that changes the state of data when a property is observed).
+/// - Is subject to the consequences of observing a calculated property. (ie, code that changes the state of data when a property is observed).
 /// - Cannot respect custom `Equatable` implementations of the values being compared or any of the subsequent members. It will use its own comparison logic instead.
 /// - Skips over members that cannot be reasonably compared, such as closures. These are assumed to be equal.
-/// - Does not support recursive evaluation of reflexive types (it will crash if a property on a type references itself)
 ///
 /// ## Usage
 ///
@@ -74,6 +73,13 @@ public enum RecursiveComparator {
     }
     
     private static func compare(lhs: Any?, rhs: Any?, members: [String]) -> RecursiveComparatorResult {
+        // check for referential equality of objects
+        if let lhsObject = lhs as? AnyObject, let rhsObject = rhs as? AnyObject {
+            if lhsObject === rhsObject {
+                return .equal
+            }
+        }
+        
         // check each core value type
         if let lhs = lhs as? AnyHashable, let rhs = rhs as? AnyHashable {
             return lhs == rhs ? .equal : .unequal(.init(members: members, lhs: lhs, rhs: rhs))

--- a/Tests/TestableCombinePublishersTests/ExampleTest.swift
+++ b/Tests/TestableCombinePublishersTests/ExampleTest.swift
@@ -29,11 +29,13 @@ import XCTest
 class ExampleTest: XCTestCase {
     
     func testFail() {
-        let publisher = CurrentValueSubject<String, Error>("foo")
-        publisher
-            .expect("bar")
-            .expectSuccess()
-            .waitForExpectations(timeout: 1)
+        XCTExpectFailure() {
+            let publisher = CurrentValueSubject<String, Error>("foo")
+            publisher
+                .expect("bar")
+                .expectSuccess()
+                .waitForExpectations(timeout: 1)
+        }
     }
     
     func testPass() {


### PR DESCRIPTION
This PR introduces a fix to `AutomaticallyEquatable` which allows objects with recursive relationship to be compared for equality. It relies on referential equality to prevent recursion while still comparing all members of reference types if referential equality fails.

Other Additions

- Added unit tests to ensure the functionality of several recursive reference scenarios
- Added unit tests to ensure `Error` <-> objc `NSError` auto-conversion properties don't cause recursion problems
- Prevented intentional example unit test failure from breaking (future support for) CI builds
- Updated documentation to remove the warning about recursive relationships